### PR TITLE
BUGFIX: add join to spy_product_offer when filtering for multiple product offer references

### DIFF
--- a/src/Spryker/Zed/PriceProductOffer/Persistence/PriceProductOfferRepository.php
+++ b/src/Spryker/Zed/PriceProductOffer/Persistence/PriceProductOfferRepository.php
@@ -114,11 +114,11 @@ class PriceProductOfferRepository extends AbstractRepository implements PricePro
             $productOfferCriteriaTransfer = $priceProductOfferCriteriaTransfer->getProductOfferCriteria();
 
             if ($productOfferCriteriaTransfer->getProductOfferReferences()) {
-                $priceProductOfferQuery->filterBy(
-                    SpyProductOfferTableMap::COL_PRODUCT_OFFER_REFERENCE,
-                    $productOfferCriteriaTransfer->getProductOfferReferences(),
-                    Criteria::IN,
-                );
+                $priceProductOfferQuery->useSpyProductOfferQuery()
+                    ->filterByProductOfferReference_In(
+                        $productOfferCriteriaTransfer->getProductOfferReferences(),
+                    )
+                    ->endUse();
             }
 
             if ($productOfferCriteriaTransfer->getProductOfferReference()) {


### PR DESCRIPTION
## PR Description

Currently an error occurs while trying to resolve prices for multiple product offer references due to a missing join to spy_product_offer. 
This PR resolves this bug by adding the missing join. 

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
